### PR TITLE
Fix HTML escaping in live match scripts

### DIFF
--- a/js/live.js
+++ b/js/live.js
@@ -122,7 +122,15 @@ function renderLiveBoard(d){
     '</ol>';
 }
 
-function escapeHtml(s){ return (s||'').replace(/[&<>"']/g, c=>({ '&':'&','<':'<','>':'>','"':'"','\'':'\'' }[c])); }
+function escapeHtml(s){
+  return (s || '').replace(/[&<>"']/g, c => ({
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    "\"": "&quot;",
+    "'": "&#39;"
+  }[c]));
+}
 function shuffle(a){ for(let i=a.length-1;i>0;i--){ const j=Math.floor(Math.random()*(i+1)); [a[i],a[j]]=[a[j],a[i]]; } }
 
 // Join button logic

--- a/js/room.js
+++ b/js/room.js
@@ -93,4 +93,12 @@ function updateTimer(){
   timeLeft--;
 }
 
-function escapeHtml(s){ return (s||'').replace(/[&<>"']/g, c=>({ '&':'&','<':'<','>':'>','"':'"','\'':'\'' }[c])); }
+function escapeHtml(s){
+  return (s || '').replace(/[&<>"']/g, c => ({
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    "\"": "&quot;",
+    "'": "&#39;"
+  }[c]));
+}


### PR DESCRIPTION
## Summary
- Properly escape HTML special characters in `live.js` and `room.js`
- Prevent user-provided names from injecting markup into leaderboards

## Testing
- `node --check js/live.js && echo 'live ok'`
- `node --check js/room.js && echo 'room ok'`
- `node - <<'NODE'
function escapeHtml(s){
  return (s || '').replace(/[&<>"']/g, c => ({
    "&": "&amp;",
    "<": "&lt;",
    ">": "&gt;",
    "\"": "&quot;",
    "'": "&#39;"
  }[c]));
}
console.log(escapeHtml('<div>Tom & "Jerry"\'s</div>'));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a0b4eb53b083279df7966d07e9f1cf